### PR TITLE
Added ubuntu 14.04 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore output
+**/packages

--- a/distros/ubuntu/14.04/Dockerfile
+++ b/distros/ubuntu/14.04/Dockerfile
@@ -1,0 +1,11 @@
+FROM flb-build-base-ubuntu/14.04
+
+ARG FLB_PREFIX
+ARG FLB_VERSION
+
+ENV FLB_TARBALL http://github.com/fluent/fluent-bit/archive/$FLB_PREFIX$FLB_VERSION.zip
+
+RUN wget -O "/tmp/fluent-bit-${FLB_VERSION}.zip" ${FLB_TARBALL} && \
+    cd /tmp && unzip "fluent-bit-$FLB_VERSION.zip"
+
+CMD cd "/tmp/fluent-bit-${FLB_VERSION}/" && ./debian.sh && cp ../*.deb /output

--- a/distros/ubuntu/14.04/Dockerfile.base
+++ b/distros/ubuntu/14.04/Dockerfile.base
@@ -1,0 +1,6 @@
+FROM ubuntu:14.04
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get -qq update && \
+    apt-get install -y -qq curl ca-certificates build-essential cmake3 make bash sudo wget unzip nano vim valgrind dh-make && \
+    apt-get install -y -qq --reinstall lsb-base lsb-release


### PR DESCRIPTION
This patch adds support for Ubuntu 14.04; For this to make it work correctly
PR fluent/fluent-bit#826 needs to be merged.

Resulting package tested on Ubuntu 14.04.

Signed-off-by: Zsolt Kulcsar <zskulcsar@gmail.com>