### PR TITLE
debian/stretch install: add systemd support

### DIFF
--- a/distros/debian/stretch/Dockerfile.base
+++ b/distros/debian/stretch/Dockerfile.base
@@ -2,5 +2,7 @@ FROM debian:stretch-slim
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -qq update && \
-    apt-get install -y -qq curl ca-certificates build-essential cmake make bash sudo wget unzip dh-make && \
+    apt-get install -y -qq curl ca-certificates build-essential \
+                           cmake make bash sudo wget unzip dh-make \
+                           libsystemd-dev zlib1g-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release


### PR DESCRIPTION
libsystemd-dev was missing (and the corresponding zlib-dev),
causing the configure to not enable the systemd input system.

Signed-off-by: Don Bowman <db@donbowman.ca>