### PR TITLE
Fix missing gelf output plugin issue

### DIFF
--- a/distros/centos/7/Dockerfile.base
+++ b/distros/centos/7/Dockerfile.base
@@ -1,7 +1,7 @@
 FROM centos:7
 
 RUN yum -y update && \
-    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash wget unzip systemd-devel wget flex bison && \
+    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash wget unzip zlib-devel systemd-devel wget flex bison && \
     wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     rpm -ivh epel-release-latest-7.noarch.rpm && \
     yum install -y cmake3


### PR DESCRIPTION
If zlib cannot be found during the build the gelf output plugin will not be added to fluent-bit.
This adds the missing zlib dependency that is included in the official docker image.