### PR TITLE
Add CentOS 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository contains Docker files used to build [Fluent Bit](http://fluentbi
 
 | Distro       |   Version / Code Name   | Arch   | Target Option           |
 |--------------|-------------------------|--------|-------------------------|
+| CentOS       |   6                     | amd64  | centos/6                |
 | CentOS       |   7                     | amd64  | centos/7                |
 | Debian       |   8                     | amd64  | debian/jessie           |
 | Debian       |   9                     | amd64  | debian/stretch          |

--- a/distros/centos/6/Dockerfile
+++ b/distros/centos/6/Dockerfile
@@ -1,0 +1,16 @@
+FROM flb-build-base-centos/6
+
+ARG FLB_PREFIX
+ARG FLB_VERSION
+
+ENV FLB_TARBALL http://github.com/fluent/fluent-bit/archive/$FLB_PREFIX$FLB_VERSION.zip
+
+RUN cd /tmp && \
+    wget -O "/tmp/fluent-bit-${FLB_VERSION}.zip" ${FLB_TARBALL} && \
+    unzip "fluent-bit-$FLB_VERSION.zip" && \
+    cd "/tmp/fluent-bit-${FLB_VERSION}/build" && \
+    cmake3 -DFLB_DEBUG=On -DFLB_TRACE=On -DFLB_TD=On \
+           -DFLB_BUFFERING=On -DFLB_SQLDB=On -DFLB_HTTP_SERVER=On \
+           -DFLB_OUT_KAFKA=On ../
+
+CMD cd "/tmp/fluent-bit-${FLB_VERSION}/build/" && make && cpack3 && cp *.rpm /output/

--- a/distros/centos/6/Dockerfile.base
+++ b/distros/centos/6/Dockerfile.base
@@ -1,0 +1,10 @@
+FROM centos:6
+
+RUN yum -y update && \
+    yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake3 make bash wget unzip systemd-devel wget flex && \
+    mkdir -p /tmp/bison && cd /tmp/bison && \
+    curl -Lk http://ftp.gnu.org/gnu/bison/bison-3.0.4.tar.xz|tar xJ -C /tmp/bison --strip-components=1 && \
+    ./configure && make -j$(getconf _NPROCESSORS_ONLN) && make install && \
+    wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm && \
+    rpm -ivh epel-release-latest-6.noarch.rpm && \
+    yum install -y cmake3


### PR DESCRIPTION
This PR adds support for CentOS 6. This patch has been tested on CentOS 6.9/6.10
