### PR TITLE
distros: ubuntu/16.04: fixup for COPY failure

### DIFF
--- a/distros/ubuntu/16.04/Dockerfile
+++ b/distros/ubuntu/16.04/Dockerfile
@@ -2,14 +2,12 @@ FROM flb-build-base-ubuntu/16.04
 
 ARG FLB_PREFIX
 ARG FLB_VERSION
-ARG FLB_SRC
 
-ENV FLB_TARBALL http://github.com/fluent/fluent-bit/archive/$FLB_PREFIX$FLB_VERSION.zip
-COPY sources/$FLB_SRC /
+ENV FLB_TARBALL http://github.com/fluent/fluent-bit/archive/${FLB_PREFIX}${FLB_VERSION}.zip
 
 RUN cd /tmp && \
-    if [ "x$FLB_SRC" = "x" ] ; then wget -O "/tmp/fluent-bit-${FLB_VERSION}.zip" ${FLB_TARBALL} && unzip "fluent-bit-$FLB_VERSION.zip" ; else tar zxfv "/$FLB_SRC" ; fi && \
-    cd "fluent-bit-$FLB_VERSION/build/" && \
+    wget -O "/tmp/fluent-bit-${FLB_VERSION}.zip" ${FLB_TARBALL} && unzip "fluent-bit-${FLB_VERSION}.zip" && \
+    cd "fluent-bit-${FLB_VERSION}/build/" && \
     export CFLAGS="$CFLAGS -std=gnu99" && \
     cmake  -DCMAKE_INSTALL_PREFIX=/opt/td-agent-bit/ -DCMAKE_INSTALL_SYSCONFDIR=/etc/ \
            -DFLB_DEBUG=On -DFLB_TRACE=On -DFLB_TD=On \


### PR DESCRIPTION
The COPY step fails for me unless `-t` specified.
Perhaps the optional download should be upstream of the docker building?