### PR TITLE
Add qemu-aarch64-static binary to base images.

### DIFF
--- a/distros/amazonlinux/2.arm64v8/Dockerfile.base
+++ b/distros/amazonlinux/2.arm64v8/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM arm64v8/amazonlinux:2
 
+COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
                    wget unzip systemd-devel wget flex bison \

--- a/distros/centos/7.arm64v8/Dockerfile.base
+++ b/distros/centos/7.arm64v8/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM arm64v8/centos:7
 
+COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
                    wget unzip systemd-devel wget flex bison \

--- a/distros/centos/8.arm64v8/Dockerfile.base
+++ b/distros/centos/8.arm64v8/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM arm64v8/centos:8
 
+COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
 RUN yum -y update && \
     yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
                    wget unzip systemd-devel wget flex bison \

--- a/distros/debian/buster.arm64v8/Dockerfile.base
+++ b/distros/debian/buster.arm64v8/Dockerfile.base
@@ -1,6 +1,8 @@
 FROM arm64v8/debian:buster-slim
 ENV DEBIAN_FRONTEND noninteractive
 
+COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
 RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential \
                            cmake make bash sudo wget unzip dh-make \

--- a/distros/debian/jessie.arm64v8/Dockerfile.base
+++ b/distros/debian/jessie.arm64v8/Dockerfile.base
@@ -1,6 +1,8 @@
 FROM resin/aarch64-debian:jessie
 ENV DEBIAN_FRONTEND noninteractive
 
+COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
 RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list && \
     printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\n" > /etc/apt/sources.list && \
     printf "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free\n" >> /etc/apt/sources.list && \

--- a/distros/debian/stretch.arm64v8/Dockerfile.base
+++ b/distros/debian/stretch.arm64v8/Dockerfile.base
@@ -1,6 +1,8 @@
 FROM arm64v8/debian:stretch
 ENV DEBIAN_FRONTEND noninteractive
 
+COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
 RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential \
                            cmake make bash sudo wget unzip dh-make \

--- a/distros/ubuntu/18.04.arm64v8/Dockerfile.base
+++ b/distros/ubuntu/18.04.arm64v8/Dockerfile.base
@@ -1,6 +1,8 @@
 FROM arm64v8/ubuntu:18.04
 ENV DEBIAN_FRONTEND noninteractive
 
+COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
 RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential libsystemd-dev \
     cmake make bash sudo wget unzip nano vim valgrind dh-make flex bison \

--- a/distros/ubuntu/20.04.arm64v8/Dockerfile.base
+++ b/distros/ubuntu/20.04.arm64v8/Dockerfile.base
@@ -1,6 +1,8 @@
 FROM arm64v8/ubuntu:20.04
 ENV DEBIAN_FRONTEND noninteractive
 
+COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
 RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential libsystemd-dev \
     cmake make bash sudo wget unzip nano vim valgrind dh-make flex bison \


### PR DESCRIPTION
This patch adds
COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
To all base aarch64 images.

Signed-off-by: Jnr@metaklass.org <jnr@metaklass.org>