### PR TITLE
Fix Cross-Distro Dependency Inconsistencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/packages
+**.swp
+

--- a/distros/debian/buster.arm64v8/Dockerfile.base
+++ b/distros/debian/buster.arm64v8/Dockerfile.base
@@ -7,5 +7,6 @@ RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
-                           libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all && \
+                           libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
+                           libsasl2-2 libsasl2-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release

--- a/distros/debian/buster/Dockerfile.base
+++ b/distros/debian/buster/Dockerfile.base
@@ -5,5 +5,6 @@ RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
-                           libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all && \
+                           libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
+                           libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 && \
     apt-get install -y -qq --reinstall lsb-base lsb-release

--- a/distros/debian/buster/Dockerfile.base
+++ b/distros/debian/buster/Dockerfile.base
@@ -6,5 +6,5 @@ RUN apt-get -qq update && \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
                            libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-                           libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 && \
+                           libsasl2-2 libsasl2-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release

--- a/distros/debian/stretch.arm64v8/Dockerfile.base
+++ b/distros/debian/stretch.arm64v8/Dockerfile.base
@@ -7,5 +7,6 @@ RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
-                           libssl1.1 libssl-dev && \
+                           libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
+                           libsasl2-2 libsasl2-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release

--- a/distros/debian/stretch/Dockerfile.base
+++ b/distros/debian/stretch/Dockerfile.base
@@ -5,5 +5,6 @@ RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
-                           libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all && \
+                           libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
+                           libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 && \
     apt-get install -y -qq --reinstall lsb-base lsb-release

--- a/distros/debian/stretch/Dockerfile.base
+++ b/distros/debian/stretch/Dockerfile.base
@@ -6,5 +6,5 @@ RUN apt-get -qq update && \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
                            libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
-                           libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 && \
+                           libsasl2-2 libsasl2-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release

--- a/distros/opensuse/leap/Dockerfile.base
+++ b/distros/opensuse/leap/Dockerfile.base
@@ -3,4 +3,5 @@ FROM opensuse/leap:latest
 RUN zypper -n update && \
     zypper -n install curl ca-certificates gcc gcc-c++ systemd-devel cmake make\
     bash sudo wget unzip nano vim valgrind dh-make flex bison rpmbuild \
-    postgresql postgresql-devel
+    postgresql postgresql-devel \
+    cyrus-sasl-devel cyrus-sasl openssl-1_1 libopenssl1_1 libopenssl-1_1-devel

--- a/distros/raspbian/buster/Dockerfile.base
+++ b/distros/raspbian/buster/Dockerfile.base
@@ -5,5 +5,6 @@ RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential \
                            cmake make bash sudo wget unzip dh-make \
                            libsystemd-dev zlib1g-dev flex bison \
-                           libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all && \
+                           libssl1.1 libssl-dev libpq-dev postgresql-server-dev-all \
+                           libsasl2-2 libsasl2-dev && \
     apt-get install -y -qq --reinstall lsb-base lsb-release

--- a/distros/ubuntu/18.04.arm64v8/Dockerfile.base
+++ b/distros/ubuntu/18.04.arm64v8/Dockerfile.base
@@ -6,5 +6,6 @@ COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-stat
 RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential libsystemd-dev \
     cmake make bash sudo wget unzip nano vim valgrind dh-make flex bison \
-    libpq-dev postgresql-server-dev-all && \
+    libpq-dev postgresql-server-dev-all \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 && \
     apt-get install -y -qq --reinstall lsb-base lsb-release

--- a/distros/ubuntu/18.04/Dockerfile.base
+++ b/distros/ubuntu/18.04/Dockerfile.base
@@ -4,5 +4,6 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential libsystemd-dev \
     cmake make bash sudo wget unzip nano vim valgrind dh-make flex bison \
-    libpq-dev postgresql-server-dev-all && \
+    libpq-dev postgresql-server-dev-all \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 && \
     apt-get install -y -qq --reinstall lsb-base lsb-release

--- a/distros/ubuntu/20.04.arm64v8/Dockerfile.base
+++ b/distros/ubuntu/20.04.arm64v8/Dockerfile.base
@@ -6,5 +6,6 @@ COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-stat
 RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential libsystemd-dev \
     cmake make bash sudo wget unzip nano vim valgrind dh-make flex bison \
-    libpq-dev postgresql-server-dev-all && \
+    libpq-dev postgresql-server-dev-all \
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 && \
     apt-get install -y -qq --reinstall lsb-base lsb-release

--- a/distros/ubuntu/20.04/Dockerfile.base
+++ b/distros/ubuntu/20.04/Dockerfile.base
@@ -4,5 +4,6 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -qq update && \
     apt-get install -y -qq curl ca-certificates build-essential libsystemd-dev \
     cmake make bash sudo wget unzip nano vim valgrind dh-make flex bison \
-    libpq-dev postgresql-server-dev-all && \
+    libpq-dev postgresql-server-dev-all \ 
+    libsasl2-2 libsasl2-dev openssl libssl-dev libssl1.1 && \
     apt-get install -y -qq --reinstall lsb-base lsb-release


### PR DESCRIPTION
Adjusts dependencies for currently supported distros to be more consistent. Adds cyrus-sasl2 and openssl libraries to all distros to maintain consistency with CentOS 7. This fixes https://github.com/fluent/fluent-bit/issues/4085 where Ubuntu builds aren't built against OpenSSL and have issues with some TLS certs.

I only tested the changes against Ubuntu 20.04, but confirmed that all modified X86 distros still build. I wasn't able to test ARM64 builds since they don't appear to be setup for cross compile properly, and I don't have an ARM64 device readily available.

Also note that the current build script only checks if the docker images exist, but doesn't check for changes. If the build environment remains between builds, this will be problematic as images will be using old dependencies and won't include the new changes in this PR. As a result, if this will be problematic in the build environment, I would suggest always rebuilding the Docker base images entirely.